### PR TITLE
Ensure every folder has editable metadata

### DIFF
--- a/index.html
+++ b/index.html
@@ -2569,28 +2569,34 @@
                 el.addEventListener("click", function (e) {
                   e.stopPropagation();
                   const path = getFullPath(this);
-                  const meta = folderMeta[path.toLowerCase()];
-                  if (meta !== undefined) {
-                    const parts = path.split(" > ");
-                    const name = parts[parts.length - 1];
-                    document.getElementById("infoName").textContent = name;
-                    document.getElementById("infoPath").textContent = path;
-                    document.getElementById("infoComments").textContent =
-                      meta["Comments"] !== "" ? meta["Comments"] : "None";
-                    document.getElementById("infoRead").textContent =
-                      meta["Read Access"] !== "" ? meta["Read Access"] : "None";
-                    document.getElementById("infoWrite").textContent =
-                      meta["Write Access"] !== ""
-                        ? meta["Write Access"]
-                        : "None";
-                    document.getElementById("infoFilename").textContent =
-                      meta["Filename Sample"] !== ""
-                        ? meta["Filename Sample"]
-                        : "None";
-                    document.getElementById("infoBox").style.display = "block";
-                  } else {
-                    document.getElementById("infoBox").style.display = "none";
+                  const key = path.toLowerCase();
+                  const name = path.split(" > ").pop();
+                  if (!folderMeta[key]) {
+                    folderMeta[key] = {
+                      Name: name,
+                      Path: path,
+                      Comments: "",
+                      "Read Access": "",
+                      "Write Access": "",
+                      "Filename Sample": "",
+                    };
                   }
+                  const meta = folderMeta[key];
+                  document.getElementById("infoName").textContent = meta.Name;
+                  document.getElementById("infoPath").textContent = meta.Path;
+                  document.getElementById("infoComments").textContent =
+                    meta["Comments"] !== "" ? meta["Comments"] : "None";
+                  document.getElementById("infoRead").textContent =
+                    meta["Read Access"] !== "" ? meta["Read Access"] : "None";
+                  document.getElementById("infoWrite").textContent =
+                    meta["Write Access"] !== ""
+                      ? meta["Write Access"]
+                      : "None";
+                  document.getElementById("infoFilename").textContent =
+                    meta["Filename Sample"] !== ""
+                      ? meta["Filename Sample"]
+                      : "None";
+                  document.getElementById("infoBox").style.display = "block";
                   showFolderActions(this);
                 });
               }
@@ -2622,6 +2628,36 @@
                 }
                 return path.join(" > ");
               }
+
+              function initializeMetaForAllFolders() {
+                document.querySelectorAll("#folderTree li").forEach((el) => {
+                  const path = getFullPath(el);
+                  const key = path.toLowerCase();
+                  const name = path.split(" > ").pop();
+                  if (!folderMeta[key]) {
+                    folderMeta[key] = {
+                      Name: name,
+                      Path: path,
+                      Comments: "",
+                      "Read Access": "",
+                      "Write Access": "",
+                      "Filename Sample": "",
+                    };
+                  } else {
+                    folderMeta[key].Name = folderMeta[key].Name || name;
+                    folderMeta[key].Path = folderMeta[key].Path || path;
+                    folderMeta[key]["Comments"] =
+                      folderMeta[key]["Comments"] || "";
+                    folderMeta[key]["Read Access"] =
+                      folderMeta[key]["Read Access"] || "";
+                    folderMeta[key]["Write Access"] =
+                      folderMeta[key]["Write Access"] || "";
+                    folderMeta[key]["Filename Sample"] =
+                      folderMeta[key]["Filename Sample"] || "";
+                  }
+                });
+              }
+              initializeMetaForAllFolders();
 
               function checkPasscode() {
                 const pass = prompt("Enter passcode:");
@@ -2679,7 +2715,11 @@
                 const newPath = parts.join(" > ");
                 if (meta) {
                   delete folderMeta[oldPath.toLowerCase()];
-                  folderMeta[newPath.toLowerCase()] = meta;
+                  folderMeta[newPath.toLowerCase()] = {
+                    ...meta,
+                    Name: newName,
+                    Path: newPath,
+                  };
                 }
                 if (
                   document.getElementById("infoPath").textContent === oldPath
@@ -2749,9 +2789,12 @@
                 const parentPath = getFullPath(li);
                 const newPath = parentPath + " > " + name;
                 folderMeta[newPath.toLowerCase()] = {
+                  Name: name,
+                  Path: newPath,
                   Comments: "",
                   "Read Access": "",
                   "Write Access": "",
+                  "Filename Sample": "",
                 };
               }
 
@@ -2774,15 +2817,9 @@
                 const li = e.target.closest("li");
                 const path = getFullPath(li);
                 currentEditPath = path;
-                const meta = folderMeta[path.toLowerCase()] || {
-                  Comments: "",
-                  "Read Access": "",
-                  "Write Access": "",
-                };
-                document.getElementById("editName").value = path
-                  .split(" > ")
-                  .pop();
-                document.getElementById("editPath").value = path;
+                const meta = folderMeta[path.toLowerCase()];
+                document.getElementById("editName").value = meta.Name;
+                document.getElementById("editPath").value = meta.Path;
                 document.getElementById("editComments").value =
                   meta["Comments"];
                 document.getElementById("editRead").value = meta["Read Access"];
@@ -2800,12 +2837,12 @@
                 const read = document.getElementById("editRead").value;
                 const write = document.getElementById("editWrite").value;
                 const filename = document.getElementById("editFilename").value;
-                folderMeta[currentEditPath.toLowerCase()] = {
-                  Comments: comments,
-                  "Read Access": read,
-                  "Write Access": write,
-                  "Filename Sample": filename,
-                };
+                const meta = folderMeta[currentEditPath.toLowerCase()] || {};
+                meta["Comments"] = comments;
+                meta["Read Access"] = read;
+                meta["Write Access"] = write;
+                meta["Filename Sample"] = filename;
+                folderMeta[currentEditPath.toLowerCase()] = meta;
                 document.getElementById("infoComments").textContent =
                   comments || "None";
                 document.getElementById("infoRead").textContent =


### PR DESCRIPTION
## Summary
- auto-generate default metadata with name and path for any folder lacking details
- initialize metadata store for all folders on load
- keep metadata in sync when folders are renamed or new subfolders are added

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6894fb04f308832da9d0175e71e1fd2d