### PR TITLE
Fix nested level-6 nesting and update color

### DIFF
--- a/index.html
+++ b/index.html
@@ -91,7 +91,7 @@
         color: #ffbe00; /* Bright Yellow */
       }
       .level-6 {
-        color: red; /* Red */
+        color: orange; /* Orange */
       }
       .level-7 {
         color: #d81639; /* Deep Red */
@@ -339,7 +339,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IAL</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -362,7 +362,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IKT</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -380,7 +380,7 @@
                               <li class="level-6">
                                 <span class="caret">Indonesia</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IRS</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -403,7 +403,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IKF</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -416,7 +416,7 @@
                                       <li class="level-6">📁Treasury</li>
                                     </ul>
                                   </li>
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">FAI</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -434,7 +434,7 @@
                               <li class="level-6">
                                 <span class="caret">Georgia</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">RAI</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -476,7 +476,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IAL</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -499,7 +499,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IKT</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -517,7 +517,7 @@
                               <li class="level-6">
                                 <span class="caret">Indonesia</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IRS</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -540,7 +540,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IKF</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -553,7 +553,7 @@
                                       <li class="level-6">📁Treasury</li>
                                     </ul>
                                   </li>
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">FAI</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -571,7 +571,7 @@
                               <li class="level-6">
                                 <span class="caret">Georgia</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">RAI</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -608,7 +608,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IAL</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -631,7 +631,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IKT</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -649,7 +649,7 @@
                               <li class="level-6">
                                 <span class="caret">Indonesia</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IRS</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -672,7 +672,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IKF</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -685,7 +685,7 @@
                                       <li class="level-6">📁Treasury</li>
                                     </ul>
                                   </li>
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">FAI</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -703,7 +703,7 @@
                               <li class="level-6">
                                 <span class="caret">Georgia</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">RAI</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -732,7 +732,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IAL</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -755,7 +755,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IKT</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -773,7 +773,7 @@
                               <li class="level-6">
                                 <span class="caret">Indonesia</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IRS</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -796,7 +796,7 @@
                               <li class="level-6">
                                 <span class="caret">Uzbekistan</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">IKF</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -809,7 +809,7 @@
                                       <li class="level-6">📁Treasury</li>
                                     </ul>
                                   </li>
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">FAI</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>
@@ -827,7 +827,7 @@
                               <li class="level-6">
                                 <span class="caret">Georgia</span>
                                 <ul class="nested">
-                                  <li class="level-6">
+                                  <li class="level-7">
                                     <span class="caret">RAI</span>
                                     <ul class="nested">
                                       <li class="level-6">📁OTC</li>


### PR DESCRIPTION
## Summary
- Use orange styling for level-6 list items
- Correct nested structure by converting inner level-6 folders (e.g. IAL, IKT) to level-7

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68951d0cad80832d872b52754975bc21