### PR TITLE
Use lime green for level-5 class color

### DIFF
--- a/index.html
+++ b/index.html
@@ -88,7 +88,7 @@
         color: #b1c95d; /* Light Olive Green */
       }
       .level-5 {
-        color: #FFFB00; /* Bright Yellow */
+        color: #00FF00; /* Lime Green */
       }
       .level-6 {
         color: #FFB800; /* Golden Yellow */


### PR DESCRIPTION
## Summary
- Change `.level-5` color to lime green (#00FF00) for improved styling

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952499f2c4832db21ecdc9afb6f9f4