### PR TITLE
Persist folder data in downloaded HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -2903,7 +2903,12 @@
               }
 
               function downloadHTML() {
-                const html = document.documentElement.outerHTML;
+                const meta = JSON.stringify(folderMeta, null, 2);
+                let html = document.documentElement.outerHTML;
+                html = html.replace(
+                  /const folderMeta = {[^]*?};/,
+                  "const folderMeta = " + meta + ";"
+                );
                 const blob = new Blob([html], { type: "text/html" });
                 const url = URL.createObjectURL(blob);
                 const a = document.createElement("a");


### PR DESCRIPTION
## Summary
- Update downloadHTML to embed the current `folderMeta` state before saving, ensuring CRUD changes appear in the downloaded file.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68952eb43988832d8010c1b23acbf32e