### PR TITLE
Fix Folder Details box width overflowing screen

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,23 +182,26 @@
         display: flex;
         align-items: flex-start;
         gap: 20px;
+        flex-wrap: wrap;
       }
 
       .tree-section {
-        flex: 0 0 70%;
+        flex: 0 1 70%;
         max-height: 80vh; /* allow scrolling for long folder lists */
         overflow-y: auto;
       }
 
       #infoBox {
-        flex: 0 0 30%;
-        width: 30%;
+        flex: 0 1 30%;
+        max-width: 30%;
+        box-sizing: border-box;
         background: #fff;
         border: 1px solid #ccc;
         border-radius: 8px;
         box-shadow: 2px 2px 12px rgba(0, 0, 0, 0.1);
         padding: 15px;
         display: none;
+        overflow-wrap: break-word;
       }
 
       /* styling for edit details form */


### PR DESCRIPTION
## Summary
- prevent Folder Details panel from stretching past screen bounds
- allow main container to wrap and break long text in details box

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_689533459f08832daa6ae225c6a1f1d2