### PR TITLE
Keep folder details box on the right

### DIFF
--- a/index.html
+++ b/index.html
@@ -182,7 +182,7 @@
         display: flex;
         align-items: flex-start;
         gap: 20px;
-        flex-wrap: wrap;
+        flex-wrap: nowrap;
       }
 
       .tree-section {


### PR DESCRIPTION
## Summary
- Prevent main container wrapping so folder details panel stays on the right.

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689534760dbc832d870a8a5163f3da0a