### PR TITLE
Hide folder details until folder selected

### DIFF
--- a/index.html
+++ b/index.html
@@ -4075,7 +4075,7 @@
           </li>
         </ul>
       </div>
-      <div id="infoBox" style="display: block;">
+      <div id="infoBox" style="display: none;">
         <h3 style="margin-top: 0">📄 Folder Details</h3>
         <div id="infoDisplay" style="display: block;">
           <p><strong>📁 Name:</strong> <span id="infoName">GE Sign Off Emails</span></p>


### PR DESCRIPTION
## Summary
- Hide folder details pane on initial load so it only appears after a folder is clicked

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6895c4eb3470832da4c9f009d0ac9c10