### PR TITLE
Fix toggle on downloaded HTML

### DIFF
--- a/index.html
+++ b/index.html
@@ -1016,20 +1016,25 @@
               
             <li class="level-2">📁Data Management</li><li class="level-2">📁Pre Go Live</li><li class="level-2">📁Go Live</li><li class="level-2">📁PGLS</li></ul>
             <script>
-              const togglers = document.getElementsByClassName("caret");
-              for (let i = 0; i < togglers.length; i++) {
-                togglers[i].classList.add("folder-closed");
-                togglers[i].addEventListener("click", function () {
-                  const nestedList =
-                    this.parentElement.querySelector(".nested");
-                  if (nestedList) {
-                    nestedList.classList.toggle("active");
-                    this.classList.toggle("caret-down");
-                    this.classList.toggle("folder-open");
-                    this.classList.toggle("folder-closed");
-                  }
-                });
+              function initializeTogglers() {
+                const togglers = document.getElementsByClassName("caret");
+                for (let i = 0; i < togglers.length; i++) {
+                  togglers[i].classList.add("folder-closed");
+                  togglers[i].addEventListener("click", function () {
+                    const nestedList = this.parentElement.querySelector(
+                      ".nested"
+                    );
+                    if (nestedList) {
+                      nestedList.classList.toggle("active");
+                      this.classList.toggle("caret-down");
+                      this.classList.toggle("folder-open");
+                      this.classList.toggle("folder-closed");
+                    }
+                  });
+                }
               }
+
+              document.addEventListener("DOMContentLoaded", initializeTogglers);
 
               function expandAll() {
                 document


### PR DESCRIPTION
## Summary
- ensure folder toggles initialize after page load so exported HTML expands/collapses

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6898df585910832d884c5f3021e9a56d