### PR TITLE
Fix HTML export and timestamp download

### DIFF
--- a/index.html
+++ b/index.html
@@ -4481,7 +4481,7 @@
                 const meta = JSON.stringify(folderMeta, null, 2);
                 let html = "<!DOCTYPE html>\n" + document.documentElement.outerHTML;
                 const marker = "const folderMeta = ";
-                const start = html.lastIndexOf(marker);
+                const start = html.indexOf(marker);
                 if (start !== -1) {
                   const end = html.indexOf("};", start) + 2;
                   html =
@@ -4495,7 +4495,13 @@
                 const url = URL.createObjectURL(blob);
                 const a = document.createElement("a");
                 a.href = url;
-                a.download = "updated.html";
+                const now = new Date();
+                const timestamp = now
+                  .toISOString()
+                  .replace("T", " ")
+                  .replace(/:/g, "-")
+                  .slice(0, 19);
+                a.download = `EY DOC folder tree updated(${timestamp}).html`;
                 a.click();
                 URL.revokeObjectURL(url);
               }


### PR DESCRIPTION
## Summary
- Ensure folder metadata is correctly embedded when exporting HTML
- Include date/time stamp in downloaded HTML filename

## Testing
- `npm test` *(fails: ENOENT Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689a22a194ac832d83e633bddc307806